### PR TITLE
Replace Class::MOP::load_class with Module::Runtime::use_module

### DIFF
--- a/Build.PL
+++ b/Build.PL
@@ -12,6 +12,7 @@ my $build = Module::Build->new(
         'IO::String'              => '0',
         'Moose'                   => '0.18',           
         'MooseX::Param'           => '0.01',                   
+        'Module::Runtime'         => '0',
         # for Test::Excel::Template::Plus
         'Test::Deep'              => '0',
         'Spreadsheet::ParseExcel' => '0',                     

--- a/lib/Excel/Template/Plus.pm
+++ b/lib/Excel/Template/Plus.pm
@@ -1,6 +1,7 @@
 
 package Excel::Template::Plus;
 use Moose;
+use Module::Runtime ();
 
 our $VERSION   = '0.05';
 our $AUTHORITY = 'cpan:STEVAN';
@@ -11,7 +12,7 @@ sub new {
     
     my $engine_class = 'Excel::Template::Plus::' . $options{engine};
 
-    eval { Class::MOP::load_class($engine_class) };
+    eval { Module::Runtime::use_module($engine_class) };
     if ($@) {
         confess "Could not load engine class ($engine_class) because " . $@;
     }

--- a/lib/Excel/Template/Plus/TT.pm
+++ b/lib/Excel/Template/Plus/TT.pm
@@ -5,6 +5,7 @@ use Moose::Util::TypeConstraints;
 
 use Template   ();
 use IO::String ();
+use Module::Runtime ();
 
 use Excel::Template;
 
@@ -42,7 +43,7 @@ has '_template_object' => (
     default => sub {
         my $self = shift;
         my $class = $self->template_class;
-        Class::MOP::load_class($class);
+        Module::Runtime::use_module($class);
         ($class->isa('Template'))
             || confess "The template_class must be Template or a subclass of it";
         $class->new( $self->config )


### PR DESCRIPTION
Class::MOP::load_class() was deprecated in Moose 2.02. The POD for Moose
recommends switching to using Module::Runtime directly.

https://metacpan.org/pod/release/ETHER/Moose-2.1106-TRIAL/lib/Moose/Manual/Delta.pod#pod2.1200
